### PR TITLE
fix(ci): skip changeset check on Version Packages PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: pnpm run check:lockfile
 
       - name: Check changesets
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
         run: pnpm exec changeset status --since=origin/${{ github.base_ref }}
 
       - name: Build


### PR DESCRIPTION
Skip the changeset status check when the PR is from changeset-release/main (the automated Version Packages PR). This PR has version bumps but no changeset files (they were consumed by changeset version), so the check incorrectly fails.