### PR TITLE
fix: back-top demos and sidebar scrollIntoView

### DIFF
--- a/.agents/rules/code-style.md
+++ b/.agents/rules/code-style.md
@@ -9,5 +9,6 @@
 - 内部状态与行为实现使用 `import { definePlugin } from '@greypan/js-kit'` 的插件系统，不使用 `class` 封装；Lit 自定义元素等框架要求继承的类型不在此限。
 - 插件构建器命名为 `defineXxx`，并以 `defineXxx = (...) => definePlugin(...)` 形式返回插件；调用端使用 `defineXxx(...).make(...)`。
 - CSS 的组件内部后代状态优先使用原生 nesting 组织；`:host(...)` 状态选择器保持顶层，避免混淆 Shadow DOM 宿主边界。
+- `apps/` 下的项目编写样式时，优先使用 Tailwind v4 工具类（含 arbitrary properties 和 arbitrary variants）；仅在 Tailwind 无法表达的场景（如 keyframes、复杂嵌套选择器）才允许使用 CSS 文件兜底。
 - 格式化工具负责 import 排序；不要手工对抗其输出。
 - 完成代码改动后，先运行 `pnpm run check:code`，再向用户报告结果。

--- a/.changeset/dirty-numbers-sleep.md
+++ b/.changeset/dirty-numbers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@greypan/web-ui': patch
+---
+
+provide back-top position css var

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ Constraints:
 - Before starting a local dev server, check whether the target port already has a responsive server for the required app. Reuse it when it is suitable; do not create a duplicate server merely because a verification task starts.
 - Start a new server only when no suitable server is running, the existing one cannot serve the required current state, or an isolated environment is explicitly needed. Use an unused port in that case and record its exact PID.
 - Only stop a server started by the current task. Never terminate a pre-existing server owned by the user or another task.
+- When encountering a stale or unresponsive dev server on the target port, ask the user before killing it. Clean up only the servers started by the current task at the end of the session.
 - Never attach to or control the user's existing Chrome session. Verify in the browser context owned by chrome-devtools MCP or `agent-browser`, isolated from the user's working Chrome.
 - Ignore certificate errors only for local self-signed HTTPS demos; never relax certificate validation for external sites.
 - Stop every dev server started for verification after it completes, unless the user asks to keep it running. Preserve or report the local URL for follow-up.

--- a/apps/react-web-ui-demo/src/components/back-top-demo/index.tsx
+++ b/apps/react-web-ui-demo/src/components/back-top-demo/index.tsx
@@ -40,13 +40,13 @@ function BackTopDemo() {
 
       <h2>页面级滚动</h2>
       <p className="mb-2 text-sm text-[var(--wui-color-text-muted)]">
-        向下滚动页面超过阈值后出现按钮，点击或按 Enter 回到顶部。站点右下角已挂载全局按钮， 本示例通过{' '}
-        <code>--web-ui-back-top-left / --web-ui-back-top-right</code> 定位到左下角以便区分。
+        向下滚动页面超过阈值后出现按钮，点击或按 Enter 回到顶部。通过 <code>--web-ui-back-top-position</code>、
+        <code>--web-ui-back-top-left</code> 等自定义属性控制按钮在容器内的定位。
       </p>
-      <div className="mb-6 min-h-80 rounded-xl border border-[var(--wui-color-border)] p-4">
-        <p>这是一个占位区域：滚动页面观察左下角的回到顶部按钮。</p>
+      <div className="mb-6 h-80 overflow-hidden rounded-xl border border-[var(--wui-color-border)] p-4 [position:relative]">
+        <p className="pb-10">这是一个占位区域：滚动页面观察左下角的回到顶部按钮。</p>
+        <web-ui-back-top className="absolute bottom-5 left-6 right-auto [--web-ui-back-top-position:absolute]"></web-ui-back-top>
       </div>
-      <web-ui-back-top className="[--web-ui-back-top-left:24px] [--web-ui-back-top-right:auto]"></web-ui-back-top>
 
       <h2>自定义滚动容器</h2>
       <p className="mb-2 text-sm text-[var(--wui-color-text-muted)]">

--- a/apps/react-web-ui-demo/src/components/root/index.tsx
+++ b/apps/react-web-ui-demo/src/components/root/index.tsx
@@ -77,7 +77,7 @@ export function Root() {
   useEffect(() => {
     void router.load().then(() => {
       requestAnimationFrame(() => {
-        const link = navSidebarRef.current?.querySelector('.router-link-exact-active')
+        const link = navSidebarRef.current?.querySelector('.active')
         link?.scrollIntoView({ block: 'center' })
       })
     })

--- a/apps/vue-web-ui-demo/src/app/index.vue
+++ b/apps/vue-web-ui-demo/src/app/index.vue
@@ -56,7 +56,7 @@ useHead({ title: () => route.meta.title })
 const navSidebar = ref<HTMLElement>()
 
 onMounted(async () => {
-  // 等待 Vue Router 完成首次导航，确保 router-link-active class 已就绪
+  // 等待 Vue Router 完成首次导航，确保 active class 已就绪
   await router.isReady()
   requestAnimationFrame(() => {
     const link = navSidebar.value?.querySelector('.router-link-exact-active')

--- a/apps/vue-web-ui-demo/src/components/back-top-demo/index.vue
+++ b/apps/vue-web-ui-demo/src/components/back-top-demo/index.vue
@@ -28,13 +28,15 @@ const instantBox = useScrollBox()
 
     <h2>页面级滚动</h2>
     <p class="mb-2 text-sm text-[var(--wui-color-text-muted)]">
-      向下滚动页面超过阈值后出现按钮，点击或按 Enter 回到顶部。站点右下角已挂载全局按钮， 本示例通过
-      <code>--web-ui-back-top-left / --web-ui-back-top-right</code> 定位到左下角以便区分。
+      向下滚动页面超过阈值后出现按钮，点击或按 Enter 回到顶部。通过
+      <code>--web-ui-back-top-position</code>、<code>--web-ui-back-top-left</code> 等自定义属性控制按钮在容器内的定位。
     </p>
-    <div class="mb-6 min-h-80 rounded-xl border border-[var(--wui-color-border)] p-4">
-      <p>这是一个占位区域：滚动页面观察左下角的回到顶部按钮。</p>
+    <div class="mb-6 h-80 overflow-hidden rounded-xl border border-[var(--wui-color-border)] p-4 [position:relative]">
+      <p class="pb-10">这是一个占位区域：滚动页面观察左下角的回到顶部按钮。</p>
+      <web-ui-back-top
+        class="absolute bottom-5 left-6 right-auto [--web-ui-back-top-position:absolute]"
+      ></web-ui-back-top>
     </div>
-    <web-ui-back-top class="page-back-top"></web-ui-back-top>
 
     <h2>自定义滚动容器</h2>
     <p class="mb-2 text-sm text-[var(--wui-color-text-muted)]">
@@ -83,10 +85,5 @@ const instantBox = useScrollBox()
   border-radius: 12px;
 
   background-color: var(--wui-color-surface-raised);
-}
-
-.page-back-top {
-  --web-ui-back-top-left: 24px;
-  --web-ui-back-top-right: auto;
 }
 </style>

--- a/packages/web-ui/src/components/back-top/style.css
+++ b/packages/web-ui/src/components/back-top/style.css
@@ -19,7 +19,7 @@
 .back-top-inner {
   pointer-events: none;
 
-  position: fixed;
+  position: var(--web-ui-back-top-position, fixed);
   z-index: var(--web-ui-back-top-z-index, var(--wui-layer-auxiliary, 20));
   top: var(--web-ui-back-top-top, auto);
   right: var(--web-ui-back-top-right, 20px);


### PR DESCRIPTION
## Changes

- **fix(web-ui)**: back-top position overridable via `--web-ui-back-top-position` CSS custom property
- **fix(apps)**: restructure back-top demos — move page-level back-top into container with absolute positioning via Tailwind
- **fix(apps)**: fix sidebar `scrollIntoView` using correct active link selector (React: `.active`, Vue: `.router-link-exact-active`)
- **docs(root)**: add Tailwind v4 preference for apps/ and stale dev server cleanup constraint
- **chore(root)**: add changeset for `@greypan/web-ui` patch release