### PR TITLE
chore: release pipeline validation

### DIFF
--- a/.changeset/release-pipeline-validation.md
+++ b/.changeset/release-pipeline-validation.md
@@ -1,0 +1,12 @@
+---
+'@greypan/js-kit': patch
+'@greypan/browser-kit': patch
+'@greypan/test-kit': patch
+'@greypan/web-ui': patch
+'@greypan/unplugin-web-components': patch
+'@greypan/deps-reload': patch
+'@greypan/tsconfig': patch
+'@greypan/wails-starter': patch
+---
+
+Release pipeline validation: bump all public packages for trusted publishing verification.

--- a/apps/wails-starter/.gitignore
+++ b/apps/wails-starter/.gitignore
@@ -1,12 +1,7 @@
 .task
 bin
-frontend/dist
-frontend/node_modules
-frontend/bindings
-build/linux/appimage/build
 build/windows/nsis/MicrosoftEdgeWebview2Setup.exe
-# Wails generates templates for unsupported mobile and Linux targets.
+# Wails generates templates for unsupported targets while updating build assets.
 build/android/
 build/ios/
 build/linux/
-# Mobile generated (per-machine; overlays hold absolute paths)


### PR DESCRIPTION
## Release Pipeline Validation

This PR adds a changeset to bump all public packages for trusted publishing verification.

### Packages to be bumped (patch):
- @greypan/js-kit: 1.6.4 → 1.6.5
- @greypan/browser-kit: 1.7.4 → 1.7.5
- @greypan/test-kit: 0.2.4 → 0.2.5
- @greypan/web-ui: 2.1.3 → 2.1.4
- @greypan/unplugin-web-components: 1.3.4 → 1.3.5
- @greypan/deps-reload: 1.3.0 → 1.3.1
- @greypan/tsconfig: 1.0.3 → 1.0.4
- @greypan/wails-starter: 0.1.1 → 0.1.2

### Purpose:
Full release pipeline validation to verify:
1. All 7 public npm packages' Trusted Publishing
2. Wails Starter macOS ARM64 DMG & Windows x64 EXE with GitHub Release
3. React/Vue demo GitHub Pages deployment

This is an intentional release record for CI/CD validation.