### PR TITLE
chore(root): add wails-starter changeset to verify version-pr dedup

### DIFF
--- a/.changeset/re-run-wails-verify.md
+++ b/.changeset/re-run-wails-verify.md
@@ -1,0 +1,5 @@
+---
+'@greypan/wails-starter': patch
+---
+
+chore(wails-starter): trigger version-pr rerun to verify concurrency dedup


### PR DESCRIPTION
Add a wails-starter patch changeset to trigger the version-PR pipeline and verify that the branch-keyed concurrency dedup (from #75) collapses the pull_request + workflow_dispatch double-run into a single CI run.