### PR TITLE
fix(ci): changeset-version needs wails for sync:version script

### DIFF
--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: ./.github/actions/setup-deps
         with:
-          mise-install: 'node pnpm'
+          wails: 'true'
 
       - id: changesets
         name: Detect pending Changesets


### PR DESCRIPTION
## 变更内容

修复 `changeset-version.yml` 中 `release:version` 脚本需要 Wails 工具链的问题。

### 问题
`release:version` 调用 `sync:version.mjs`，该脚本需要 `wails3` 命令。但之前设置的 `mise-install: 'node pnpm'` 跳过了 Go/Wails 安装，导致 `wails3` 找不到。

### 修复
将 `setup-deps` 的参数从 `mise-install: 'node pnpm'` 改为 `wails: 'true'`，安装完整的工具链（包括 Go 和 Wails）。

### 验证
- ✅ YAML 语法正确
- ✅ `wails: 'true'` 参数与 composite action 定义一致
- ✅ 与 `ci.yml` 中的用法一致