### PR TITLE
chore(apps): reset interweave version to 0.0.0

### DIFF
--- a/.changeset/chatty-hands-warn.md
+++ b/.changeset/chatty-hands-warn.md
@@ -1,7 +1,6 @@
 ---
 '@greypan/browser-kit': patch
 '@greypan/tsconfig': patch
-'@greypan/interweave': patch
 '@greypan/js-kit': patch
 '@greypan/web-ui': patch
 ---

--- a/apps/interweave/CHANGELOG.md
+++ b/apps/interweave/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @greypan/interweave
 
+## 0.0.0
+
+### Patch Changes
+
+- Reset version to 0.0.0 for fresh start
+
 ## 0.1.3
 
 ### Patch Changes

--- a/apps/interweave/build/config.yml
+++ b/apps/interweave/build/config.yml
@@ -11,7 +11,7 @@ info:
   description: 'Interweave desktop application' # The application description
   copyright: '(c) 2026, greypan' # Copyright text
   comments: 'Interweave desktop application' # Comments
-  version: '0.1.3' # The application version
+  version: '0.0.0' # The application version
   # cfBundleIconName: "appicon" # The macOS icon name in Assets.car icon bundles (optional)
   #                               # Should match the name of your .icon file without the extension
   #                               # If not set and Assets.car exists, defaults to "appicon"

--- a/apps/interweave/build/darwin/Info.dev.plist
+++ b/apps/interweave/build/darwin/Info.dev.plist
@@ -17,9 +17,9 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>0.1.3</string>
+		<string>0.0.0</string>
 		<key>CFBundleVersion</key>
-		<string>0.1.3</string>
+		<string>0.0.0</string>
 		<key>LSMinimumSystemVersion</key>
 		<string>12.0.0</string>
 		<key>NSAppTransportSecurity</key>

--- a/apps/interweave/build/darwin/Info.plist
+++ b/apps/interweave/build/darwin/Info.plist
@@ -17,9 +17,9 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>0.1.3</string>
+		<string>0.0.0</string>
 		<key>CFBundleVersion</key>
-		<string>0.1.3</string>
+		<string>0.0.0</string>
 		<key>LSMinimumSystemVersion</key>
 		<string>12.0.0</string>
 		<key>NSHighResolutionCapable</key>

--- a/apps/interweave/build/windows/info.json
+++ b/apps/interweave/build/windows/info.json
@@ -1,10 +1,10 @@
 {
   "fixed": {
-    "file_version": "0.1.3"
+    "file_version": "0.0.0"
   },
   "info": {
     "0000": {
-      "ProductVersion": "0.1.3",
+      "ProductVersion": "0.0.0",
       "CompanyName": "greypan",
       "FileDescription": "Interweave desktop application",
       "LegalCopyright": "(c) 2026, greypan",

--- a/apps/interweave/build/windows/nsis/wails_tools.nsh
+++ b/apps/interweave/build/windows/nsis/wails_tools.nsh
@@ -14,7 +14,7 @@
     !define INFO_PRODUCTNAME "Interweave"
 !endif
 !ifndef INFO_PRODUCTVERSION
-    !define INFO_PRODUCTVERSION "0.1.3"
+    !define INFO_PRODUCTVERSION "0.0.0"
 !endif
 !ifndef INFO_COPYRIGHT
     !define INFO_COPYRIGHT "(c) 2026, greypan"

--- a/apps/interweave/build/windows/wails.exe.manifest
+++ b/apps/interweave/build/windows/wails.exe.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity type="win32" name="com.greypan.interweave" version="0.1.3" processorArchitecture="*"/>
+    <assemblyIdentity type="win32" name="com.greypan.interweave" version="0.0.0" processorArchitecture="*"/>
     <dependency>
         <dependentAssembly>
             <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>

--- a/apps/interweave/package.json
+++ b/apps/interweave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greypan/interweave",
-  "version": "0.1.3",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 变更内容

将 `@greypan/interweave` 版本从 0.1.3 重置为 0.0.0。

### 变更文件
- `apps/interweave/package.json` — version: 0.0.0
- `apps/interweave/build/config.yml` — version: 0.0.0
- `.changeset/chatty-hands-warn.md` — 移除 `@greypan/interweave` patch（避免版本被重新升级）

### 说明
重置版本号，为后续正式发布做准备。构建产物（Info.plist、wails.exe.manifest 等）会在下次构建时自动更新。