### PR TITLE
chore(root): exclude generated changelogs from format check

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -326,7 +326,8 @@ export default defineConfig({
       '**/auto-imports.d.ts',
       '**/typed-router.d.ts',
       'apps/interweave/frontend/bindings/**',
-      '**/.agents/skills/**' // third-party skill sources
+      '**/.agents/skills/**', // third-party skill sources
+      '**/CHANGELOG.md' // changesets 生成的 changelog，不参与格式检查
     ],
     experimentalSortImports: {
       enabled: true,


### PR DESCRIPTION
## 问题

changesets 生成的 `packages/*/CHANGELOG.md` 在列表项段落间的空行带**行尾两空格**（markdown 硬换行约定），oxfmt 0.64.0 的 markdown 规则要求清成真正空行。这导致版本 PR（changeset-release/main）的 CI 校验（workflow_dispatch 触发 `check:code`）格式检查失败——失败文件：`packages/browser-kit|js-kit|web-ui/CHANGELOG.md`。

## 修复

在 `vite.config.ts` 的 `fmt.ignorePatterns` 增加 `**/CHANGELOG.md`，与既有生成文件忽略（`dist/**`、`routeTree.gen.ts`、`bindings/**` 等）一致——changesets 生成的 changelog 不参与格式检查。

## 验证

- 用 changesets 实际生成的（含尾随空格）CHANGELOG 覆盖后跑 `vp fmt --check`：通过（658 文件全绿）
- `pnpm run check:code`：全绿

合并后，下一次 changeset-version 更新版本 PR 分支时，其 CI 会重新校验通过。