### PR TITLE
fix(root): checkout repo before running create-github-releases script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -74,10 +74,12 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.merge-sha }}
       - name: Create GitHub releases
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_SHA: ${{ needs.prepare.outputs.merge-sha }}
           PACKAGE_RELEASES: ${{ needs.prepare.outputs.package-releases }}
-        run: |
-          node .github/scripts/create-github-releases.mjs
+        run: node .github/scripts/create-github-releases.mjs


### PR DESCRIPTION
## 问题

npm-publish 的 `release-notes` job 在抽取 node 脚本到 `.github/scripts/create-github-releases.mjs` 后引用脚本文件，但该 job 原本没有 checkout（旧实现用内联 heredoc，不需要 repo 文件），导致版本 PR 合并后报 `MODULE_NOT_FOUND`。

复现：`actions/runs/32917924257` — prepare/publish job 正常（npm 已发布成功），仅 release-notes 失败（找不到 `.github/scripts/create-github-releases.mjs`）。

## 修复

给 `release-notes` job 增加 `actions/checkout@v7`（`ref: merge-sha`），与 prepare/publish 一致。