### PR TITLE
chore(root): remove local symlink find-skills

### DIFF
--- a/.agents/skills/find-skills
+++ b/.agents/skills/find-skills
@@ -1,1 +1,0 @@
-/Users/bopan/.cc-switch/skills/find-skills


### PR DESCRIPTION
Removes the `.agents/skills/find-skills` symlink that pointed to a local user path.